### PR TITLE
added  the list of all drivers since 1991 to 2023

### DIFF
--- a/scripts/list_of_drivers.sh
+++ b/scripts/list_of_drivers.sh
@@ -21,4 +21,4 @@ for ((i=0; i<=$n; i++)); do
     else
         continue
     fi   
-done > /home/madhu/Desktop/Research_Work/linux-kernel-stats/scripts/list_of_drivers_output.txt
+done 

--- a/scripts/list_of_drivers.sh
+++ b/scripts/list_of_drivers.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+SRCDIR=~/linux-stable
+cd $SRCDIR/drivers
+
+#declaring an array containing all versions
+declare -a all_versions=($(git tag -l | sort -V))  
+
+#total no. of versions
+n=${#all_versions[@]}  
+
+
+for ((i=0; i<=$n; i++)); do
+    git checkout -fq ${all_versions[$i]}
+    if [[ $? -eq 0 ]]; then
+        echo ""
+        echo ${all_versions[$i]}
+        for d in $(find ~/linux-stable/drivers/ -maxdepth 1 -type d | sed -e '/.*drivers\/$/d' | sort) ; do
+            echo "$(basename $d)"
+        done 
+    else
+        continue
+    fi   
+done > /home/madhu/Desktop/Research_Work/linux-kernel-stats/scripts/list_of_drivers_output.txt


### PR DESCRIPTION
Sample Output - 
```
v2.6.12
acorn
acpi
atm
base
block
bluetooth
cdrom
char
cpufreq
crypto
dio
edac
eisa
fc4
firmware
gpio
gpu
hid
i2c
ide
ieee1394
iio
infiniband
input
isdn
leds
macintosh
mca
md
media
message
mfd
misc
mmc
mtd
net
nfc
nubus
of
oprofile
parisc
parport
pci
pcmcia
pinctrl
pnp
s390
sbus
scsi
serial
sh
sn
spi
staging
tc
telephony
usb
video
w1
zorro

v2.6.12-rc2
acorn
acpi
atm
base
block
bluetooth
cdrom
char
cpufreq
crypto
dio
edac
eisa
fc4
firmware
gpio
gpu
hid
i2c
ide
ieee1394
iio
infiniband
input
isdn
leds
macintosh
mca
md
media
message
mfd
misc
mmc
mtd
net
nfc
nubus
of
oprofile
parisc
parport
pci
pcmcia
pinctrl
pnp
s390
sbus
scsi
serial
sh
sn
spi
staging
tc
telephony
usb
video
w1
zorro
v2.6.12-rc3
acorn
acpi
atm
base
block
bluetooth
cdrom
char
cpufreq
crypto
dio
edac
eisa
fc4
firmware
gpio
gpu
hid
i2c
ide
ieee1394
iio
infiniband
input
isdn
leds
macintosh
mca
md
media
message
mfd
misc
mmc
mtd
net
nfc
nubus
of
oprofile
parisc
parport
pci
pcmcia
pinctrl
pnp
s390
sbus
scsi
serial
sh
sn
spi
staging
tc
telephony
usb
video
w1
zorro

v2.6.12-rc4
acorn
acpi
atm
base
block
bluetooth
cdrom
char
cpufreq
crypto
dio
edac
eisa
fc4
firmware
gpio
gpu
hid
i2c
ide
ieee1394
iio
infiniband
input
isdn
leds
macintosh
mca
md
media
message
mfd
misc
mmc
mtd
net
nfc
nubus
of
oprofile
parisc
parport
pci
pcmcia
pinctrl
pnp
s390
sbus
scsi
serial
sh
sn
spi
staging
tc
telephony
usb
video
w1
zorro
```
